### PR TITLE
Optimization - Stage 2 "Generate Claims" Transaction Update

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -319,16 +319,7 @@ const deadLockRetrier = function(session, command, params, _then, _catch, _retry
     .then(
       _ => _then(),
       (err) => {
-        if (err.fields[0].code == 'Neo.ClientError.Transaction.TransactionHookFailed') {
-          console.log(clc.bold.red("Transaction Hook Failed"));
-          return _then();
-        }
-        if (err.fields[0].code == 'Neo.ClientError.Schema.ConstraintValidationFailed') {
-          console.log(clc.bold.red("Constraint Validation Failed"));
-          return _then();
-        }
-        if (err.fields[0].code !== 'Neo.TransientError.Transaction.DeadlockDetected') {
-          console.log(clc.bold.red(`Error: ${err.fields[0].code}`));
+        if (err.code !== 'Neo.TransientError.Transaction.DeadlockDetected') {
           return _catch(err);
         }
         if (_retry > 5) {

--- a/helper.js
+++ b/helper.js
@@ -319,7 +319,16 @@ const deadLockRetrier = function(session, command, params, _then, _catch, _retry
     .then(
       _ => _then(),
       (err) => {
-        if (err.code !== 'Neo.TransientError.Transaction.DeadlockDetected') {
+        if (err.fields[0].code == 'Neo.ClientError.Transaction.TransactionHookFailed') {
+          console.log(clc.bold.red("Transaction Hook Failed"));
+          return _then();
+        }
+        if (err.fields[0].code == 'Neo.ClientError.Schema.ConstraintValidationFailed') {
+          console.log(clc.bold.red("Constraint Validation Failed"));
+          return _then();
+        }
+        if (err.fields[0].code !== 'Neo.TransientError.Transaction.DeadlockDetected') {
+          console.log(clc.bold.red(`Error: ${err.fields[0].code}`));
           return _catch(err);
         }
         if (_retry > 5) {

--- a/stage-2/index.js
+++ b/stage-2/index.js
@@ -76,9 +76,9 @@ const generateClaims = function _generateClaims(neo4j, willGenerateNodes, identi
                 (start:Entity {id: claim.startID})
             USING INDEX start:Entity(id)
             
-            CREATE (end:Claim {id: claim.id})
+            MERGE (end:Claim {id: claim.id})
             SET
-                end = claim.node
+                end += claim.node
 
             WITH end, start, claim
  


### PR DESCRIPTION
There are two changes here applied to the Neo4j Transaction in the 'generate claims' function of stage-2.

1) Changing `CREATE` to `MERGE` - this ensures idempotency such that the script can be ran more than one time and get the same result.
2) Changing `SET end = claim.node` to `SET end += claim.node` - ensures that all properties from `claim.node` are copied over, and that the other existing properties in the `end` node are not overwritten.